### PR TITLE
部署別給与ランキング分析SQLの実装

### DIFF
--- a/answer/analyze_salary_ranking.sql
+++ b/answer/analyze_salary_ranking.sql
@@ -1,6 +1,3 @@
-# 課題の解答
-
-1.  **(部署ごとの平均給与を求めるクエリを作成し、結果を表示する。)**
 --CTE
 WITH department_avg AS (
   SELECT
@@ -15,7 +12,6 @@ WITH department_avg AS (
 )
 SELECT * FROM department_avg;
 
-2. **(部署内での給与ランキングを計算し、結果を表示する。)**
 --VIEW
 CREATE VIEW employee_salary_analysis AS
 WITH department_avg AS (

--- a/answer/analyze_salary_ranking.sql
+++ b/answer/analyze_salary_ranking.sql
@@ -1,0 +1,40 @@
+--CTE
+WITH department_avg AS (
+  SELECT
+    d.id AS department_id,
+    d.name AS department_name,
+    ROUND(AVG(e.salary)) AS department_avg_salary
+  FROM
+    departments d
+    JOIN employees e ON d.id = e.department_id
+  GROUP BY
+    d.id, d.name
+)
+SELECT * FROM department_avg;
+
+--VIEW
+CREATE VIEW employee_salary_analysis AS
+WITH department_avg AS (
+  SELECT
+    d.id AS department_id,
+    d.name AS department_name,
+    ROUND(AVG(e.salary)) AS department_avg_salary
+  FROM
+    departments d
+    JOIN employees e ON d.id = e.department_id
+  GROUP BY
+    d.id, d.name
+)
+SELECT
+  da.department_name,
+  e.name AS employee_name,
+  e.salary,
+  da.department_avg_salary,
+  RANK() OVER (PARTITION BY da.department_name ORDER BY e.salary DESC) AS salary_rank_in_department
+FROM
+  employees e
+  JOIN department_avg da ON e.department_id = da.department_id
+ORDER BY
+  da.department_name,
+  salary_rank_in_department;
+SELECT * FROM employee_salary_analysis;

--- a/answer/analyze_salary_ranking.sql
+++ b/answer/analyze_salary_ranking.sql
@@ -1,3 +1,6 @@
+# 課題の解答
+
+1.  **(部署ごとの平均給与を求めるクエリを作成し、結果を表示する。)**
 --CTE
 WITH department_avg AS (
   SELECT
@@ -12,6 +15,7 @@ WITH department_avg AS (
 )
 SELECT * FROM department_avg;
 
+2. **(部署内での給与ランキングを計算し、結果を表示する。)**
 --VIEW
 CREATE VIEW employee_salary_analysis AS
 WITH department_avg AS (


### PR DESCRIPTION
## 概要

部署ごとの平均給与をCTEで算出し、ウィンドウ関数を使用して部署内での給与ランキングを作成しました。
最終結果をemployee_salary_analysisビューとして作成しています。

---

## 実装内容

- **CTE**
  - departmentsテーブルとemployeesテーブルをJOINし、部署ごとの平均給与を計算
- **ウィンドウ関数**
  - RANK() OVER (PARTITION BY 部署 ORDER BY 給与 DESC) を用いて、部署内ランキングを算出
- **ビュー作成**
  - 上記結果をemployee_salary_analysisビューとして定義

---

## 動作確認

- ビューを作成後、`SELECT * FROM employee_salary_analysis;` で結果が想定通り出力されることを確認済み

---

## コメント

もしSQLの書き方やVIEW設計で改善点があればご指摘お願いします。